### PR TITLE
Support new cucumber version

### DIFF
--- a/cucumber-pretty_fail_formatter.gemspec
+++ b/cucumber-pretty_fail_formatter.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = "cucumber-pretty_fail_formatter"
-  s.version       = '0.0.4'
+  s.version       = '0.0.5'
   s.platform      = Gem::Platform::RUBY
   s.authors       = ["Philipp Tessenow"]
   s.email         = ["philipp@tessenow.org"]

--- a/cucumber-pretty_fail_formatter.gemspec
+++ b/cucumber-pretty_fail_formatter.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'cucumber', ["~> 1.3.0"]
+  s.add_dependency 'cucumber', ["~> 2.1"]
 end

--- a/lib/cucumber/formatter/pretty_fail.rb
+++ b/lib/cucumber/formatter/pretty_fail.rb
@@ -12,7 +12,7 @@ module Cucumber
     # The formatter used for <tt>--format pretty-fail</tt>
     class PrettyFail < Cucumber::Formatter::Pretty
       def initialize(runtime, path_or_io, options)
-        @runtime, @output, @options = runtime, ensure_io(path_or_io, "pretty-fail"), options
+        @runtime, @output, @options = runtime, ensure_io(path_or_io), options
         @io = StringIO.new # the fake io for the pretty formatter we inherit from
         @snippets_input = []
         @previous_step_keyword = nil


### PR DESCRIPTION
Fixes #1

In order to make it work with cucumber ~ 2.1 the only thing needed to change was the number of arguments when calling `ensure_io` (https://github.com/cucumber/cucumber-ruby/commit/c1768eb91f9399c6533cf2ff22608886514ee5f8)